### PR TITLE
Remove a redundant label

### DIFF
--- a/data/bdd100k.names
+++ b/data/bdd100k.names
@@ -11,4 +11,3 @@ tl_yellow
 tl_none
 traffic sign
 train
-tl_green


### PR DESCRIPTION
tl_green label is duplicated.
